### PR TITLE
Fix typo in README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -32,7 +32,7 @@ PathExpander.
       MY_GLOB = "**/*.rb"
 
       def initialize args = ARGV
-        super args, TEST_GLOB
+        super args, MY_GLOB
       end
     end
 


### PR DESCRIPTION
Fix the constant name in README.rdoc to match the previous defined one.
