### PR TITLE
Cast to String (`to_s`) before calling `delete_prefix`

### DIFF
--- a/lib/path_expander.rb
+++ b/lib/path_expander.rb
@@ -55,7 +55,7 @@ class PathExpander
       else
         p
       end
-    }.flatten.sort.map { |s| s.delete_prefix "./" }
+    }.flatten.sort.map { |s| s.to_s.delete_prefix "./" }
   end
 
   ##


### PR DESCRIPTION
Fixes #8

In my case I came across this when an Pronto invoked Flay which passed a Pathname to this gem.

In my opinion, it would be sane to make Pathname work, as calling `to_s` on String is harmless and it fixes an issue with Pathname.

Related request: https://bugs.ruby-lang.org/issues/18146