### PR TITLE
Normalize absolute paths inside `Dir.pwd`

### DIFF
--- a/lib/path_expander.rb
+++ b/lib/path_expander.rb
@@ -60,7 +60,7 @@ class PathExpander
     }.flatten.sort.map { |s| _normalize s }
   end
 
-  def _normalize(f) = Pathname.new(f).cleanpath.to_s # :nodoc:
+  def _normalize(f) = Pathname.new(f).cleanpath.to_s.delete_prefix("#{Dir.pwd}/") # :nodoc:
 
   ##
   # Process a file into more arguments. Override this to add

--- a/test/test_path_expander.rb
+++ b/test/test_path_expander.rb
@@ -48,6 +48,12 @@ class TestPathExpander < Minitest::Test
     assert_equal exp, expander.expand_dirs_to_files("./test")
   end
 
+  def test_expand_dirs_to_files__absolute_path
+    exp = %w[test/test_bad.rb test/test_path_expander.rb]
+
+    assert_equal exp, expander.expand_dirs_to_files("#{Dir.pwd}/test")
+  end
+
   def test_filter_files_dir
     assert_filter_files [], "test/"
     assert_filter_files_absolute_paths [], "test/"
@@ -175,12 +181,6 @@ class TestPathExpander < Minitest::Test
     assert_process_args(%w[],
                         %w[42],
                         "42")
-  end
-
-  def test_process_args_absolute_path
-    assert_process_args(%w[test/test_path_expander.rb],
-                        %w[],
-                        "#{Dir.pwd}/test/test_path_expander.rb")
   end
 
   def test_process_args_root

--- a/test/test_path_expander.rb
+++ b/test/test_path_expander.rb
@@ -177,6 +177,12 @@ class TestPathExpander < Minitest::Test
                         "42")
   end
 
+  def test_process_args_absolute_path
+    assert_process_args(%w[test/test_path_expander.rb],
+                        %w[],
+                        "#{Dir.pwd}/test/test_path_expander.rb")
+  end
+
   def test_process_args_root
     assert_process_args(%w[],
                         %w[-n /./],


### PR DESCRIPTION
Mirrors the `./` stripping already in `_normalize` so absolute
paths inside `Dir.pwd` do not break callers that follow the
README pattern of prepending `./`. See minitest/minitest#1070.